### PR TITLE
Fixed volume calculation/Autoprice for 2d Polygonal regions

### DIFF
--- a/wg6_1adapter/src/main/java/net/alex9849/adapters/WG6Region.java
+++ b/wg6_1adapter/src/main/java/net/alex9849/adapters/WG6Region.java
@@ -5,6 +5,7 @@ import com.sk89q.worldedit.BlockVector2D;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
+import com.sk89q.worldguard.protection.regions.ProtectedPolygonalRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionType;
 import net.alex9849.inter.WGRegion;
@@ -18,9 +19,15 @@ import java.util.UUID;
 public class WG6Region extends WGRegion {
 
     private ProtectedRegion region;
+    private int volume;
 
     WG6Region(ProtectedRegion region) {
         this.region = region;
+        if(region instanceof ProtectedPolygonalRegion){
+            volume = PolyArea(region.getPoints()) * (region.getMaximumPoint().getBlockY()-region.getMinimumPoint().getBlockY());
+        } else {
+            volume = region.volume();
+        }
     }
 
     public Vector getMaxPoint() {
@@ -125,7 +132,7 @@ public class WG6Region extends WGRegion {
 
     @Override
     public int getVolume() {
-        return this.region.volume();
+        return this.volume;
     }
 
     protected ProtectedRegion getRegion() {
@@ -174,5 +181,23 @@ public class WG6Region extends WGRegion {
 
     public boolean isCuboid() {
         return this.region.getType() == RegionType.CUBOID;
+    }
+
+    private static int PolyArea(List<BlockVector2D> points){
+        int axis = points.get(0).getBlockZ();
+        int total = 0;
+        int h,a,b;
+        a = 0;
+        for (int i = 1; i < points.size(); i++) {
+             h = points.get(i).getBlockX() - points.get(i-1).getBlockX();
+             b = a;
+             a = points.get(i).getBlockZ() - axis;
+             total += ((a+b)/2)*h;
+        }
+        h = points.get(0).getBlockX() - points.get(points.size()-1).getBlockX();
+        b = a;
+        a = points.get(0).getBlockZ() - axis;
+        total += ((a+b)/2)*h;
+        return total;
     }
 }

--- a/wg7adapter/src/main/java/net/alex9849/adapters/WG7Region.java
+++ b/wg7adapter/src/main/java/net/alex9849/adapters/WG7Region.java
@@ -5,6 +5,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
+import com.sk89q.worldguard.protection.regions.ProtectedPolygonalRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionType;
 import net.alex9849.inter.WGRegion;
@@ -18,9 +19,15 @@ import java.util.UUID;
 public class WG7Region extends WGRegion {
 
     private ProtectedRegion region;
+    private int Volume;
 
     WG7Region(ProtectedRegion region) {
         this.region = region;
+        if(region instanceof ProtectedPolygonalRegion){
+            Volume = PolyArea(region.getPoints()) * (region.getMaximumPoint().getBlockY()-region.getMinimumPoint().getBlockY());
+        } else {
+            Volume = region.volume();
+        }
     }
 
     public Vector getMaxPoint() {
@@ -129,7 +136,7 @@ public class WG7Region extends WGRegion {
 
     @Override
     public int getVolume() {
-        return this.region.volume();
+        return this.Volume;
     }
 
     @Override
@@ -174,5 +181,23 @@ public class WG7Region extends WGRegion {
 
     public boolean isCuboid() {
         return this.region.getType() == RegionType.CUBOID;
+    }
+
+    private static int PolyArea(List<BlockVector2> points){
+        int axis = points.get(0).getZ();
+        int total = 0;
+        int h,a,b;
+        a = 0;
+        for (int i = 1; i < points.size(); i++) {
+            h = points.get(i).getBlockX() - points.get(i-1).getBlockX();
+            b = a;
+            a = points.get(i).getBlockZ() - axis;
+            total += ((a+b)/2)*h;
+        }
+        h = points.get(0).getBlockX() - points.get(points.size()-1).getBlockX();
+        b = a;
+        a = points.get(0).getBlockZ() - axis;
+        total += ((a+b)/2)*h;
+        return total;
     }
 }


### PR DESCRIPTION
Volume for a 2d polygonal region was not provided by WorldGuard, which breaks autoprice for these region types. 
![2021-01-23_11 00 35](https://user-images.githubusercontent.com/12719375/105611680-72923380-5d6b-11eb-8c05-b20a167f1959.png)
I implemented an algorithm for calculating the volume of a 2d poly region into the worldguard adapters. Should allow Autoprice to work for polygonal regions. 