### PR TITLE
2d Polygonal Region Volume 2: Electric Boogaloo

### DIFF
--- a/wg6_1adapter/pom.xml
+++ b/wg6_1adapter/pom.xml
@@ -43,6 +43,13 @@
             <type>jar</type>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>net.alex9849</groupId>
+            <artifactId>we6adapter</artifactId>
+            <version>1.0</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/wg6_1adapter/src/main/java/net/alex9849/adapters/WG6Region.java
+++ b/wg6_1adapter/src/main/java/net/alex9849/adapters/WG6Region.java
@@ -2,6 +2,11 @@ package net.alex9849.adapters;
 
 import com.sk89q.worldedit.BlockVector;
 import com.sk89q.worldedit.BlockVector2D;
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.blocks.BaseBlock;
+import com.sk89q.worldedit.bukkit.BukkitWorld;
+import com.sk89q.worldedit.regions.Polygonal2DRegion;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
@@ -9,12 +14,12 @@ import com.sk89q.worldguard.protection.regions.ProtectedPolygonalRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionType;
 import net.alex9849.inter.WGRegion;
+import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.util.Vector;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.IntStream;
 
 public class WG6Region extends WGRegion {
 
@@ -24,7 +29,7 @@ public class WG6Region extends WGRegion {
     WG6Region(ProtectedRegion region) {
         this.region = region;
         if(region instanceof ProtectedPolygonalRegion){
-            volume = PolyArea(region.getPoints()) * (region.getMaximumPoint().getBlockY()-region.getMinimumPoint().getBlockY());
+            volume = polyArea(region.getPoints()) * (region.getMaximumPoint().getBlockY()-region.getMinimumPoint().getBlockY());
         } else {
             volume = region.volume();
         }
@@ -183,21 +188,12 @@ public class WG6Region extends WGRegion {
         return this.region.getType() == RegionType.CUBOID;
     }
 
-    private static int PolyArea(List<BlockVector2D> points){
-        int axis = points.get(0).getBlockZ();
-        int total = 0;
-        int h,a,b;
-        a = 0;
-        for (int i = 1; i < points.size(); i++) {
-             h = points.get(i).getBlockX() - points.get(i-1).getBlockX();
-             b = a;
-             a = points.get(i).getBlockZ() - axis;
-             total += ((a+b)/2)*h;
-        }
-        h = points.get(0).getBlockX() - points.get(points.size()-1).getBlockX();
-        b = a;
-        a = points.get(0).getBlockZ() - axis;
-        total += ((a+b)/2)*h;
-        return total;
+
+    public static int polyArea(List<BlockVector2D> points){
+        Polygonal2DRegion region = new Polygonal2DRegion(new BukkitWorld(Bukkit.getWorld("world")),points,0,0);
+        EditSession es = WorldEdit.getInstance().getEditSessionFactory().getEditSession(new BukkitWorld(Bukkit.getWorld("world")), Integer.MAX_VALUE);
+        Set<Integer> set = new HashSet<>();
+        IntStream.range(0, BaseBlock.MAX_ID).forEach((i) -> {set.add(new Integer(i));});
+        return es.countBlock(region,set) + 1; //this function reliably miscounts by one in all my testing. I don't know why.
     }
 }

--- a/wg6_1adapter/src/main/java/net/alex9849/adapters/WG6Region.java
+++ b/wg6_1adapter/src/main/java/net/alex9849/adapters/WG6Region.java
@@ -5,6 +5,7 @@ import com.sk89q.worldedit.BlockVector2D;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
+import com.sk89q.worldguard.protection.regions.ProtectedPolygonalRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionType;
 import net.alex9849.inter.WGRegion;
@@ -18,9 +19,15 @@ import java.util.UUID;
 public class WG6Region extends WGRegion {
 
     private ProtectedRegion region;
+    private int volume;
 
     WG6Region(ProtectedRegion region) {
         this.region = region;
+        if(region instanceof ProtectedPolygonalRegion){
+            volume = PolyArea(region.getPoints()) * (region.getMaximumPoint().getBlockY()-region.getMinimumPoint().getBlockY());
+        } else {
+            volume = region.volume();
+        }
     }
 
     public Vector getMaxPoint() {
@@ -125,7 +132,7 @@ public class WG6Region extends WGRegion {
 
     @Override
     public int getVolume() {
-        return this.region.volume();
+        return this.volume;
     }
 
     protected ProtectedRegion getRegion() {
@@ -174,5 +181,23 @@ public class WG6Region extends WGRegion {
 
     public boolean isCuboid() {
         return this.region.getType() == RegionType.CUBOID;
+    }
+
+    private static int PolyArea(List<BlockVector2D> points){
+        int axis = points.get(0).getBlockZ();
+        int total = 0;
+        int h,a,b;
+        a = 0;
+        for (int i = 1; i < points.size(); i++) {
+             h = points.get(i).getBlockX() - points.get(i-1).getBlockX();
+             b = a;
+             a = points.get(i).getBlockZ() - axis;
+             total += ((a+b)/2)*h;
+        }
+        h = points.get(0).getBlockX() - points.get(points.size()-1).getBlockX();
+        b = a;
+        a = points.get(0).getBlockZ() - axis;
+        total += ((a+b)/2)*h;
+        return total;
     }
 }

--- a/wg7adapter/src/main/java/net/alex9849/adapters/WG7Region.java
+++ b/wg7adapter/src/main/java/net/alex9849/adapters/WG7Region.java
@@ -1,7 +1,12 @@
 package net.alex9849.adapters;
 
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.bukkit.BukkitWorld;
+import com.sk89q.worldedit.function.mask.Masks;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.Polygonal2DRegion;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
@@ -9,12 +14,12 @@ import com.sk89q.worldguard.protection.regions.ProtectedPolygonalRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionType;
 import net.alex9849.inter.WGRegion;
+import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.util.Vector;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.IntStream;
 
 public class WG7Region extends WGRegion {
 
@@ -24,7 +29,7 @@ public class WG7Region extends WGRegion {
     WG7Region(ProtectedRegion region) {
         this.region = region;
         if(region instanceof ProtectedPolygonalRegion){
-            Volume = PolyArea(region.getPoints()) * (region.getMaximumPoint().getBlockY()-region.getMinimumPoint().getBlockY());
+            Volume = polyArea(region.getPoints()) * (region.getMaximumPoint().getBlockY()-region.getMinimumPoint().getBlockY());
         } else {
             Volume = region.volume();
         }
@@ -183,21 +188,9 @@ public class WG7Region extends WGRegion {
         return this.region.getType() == RegionType.CUBOID;
     }
 
-    private static int PolyArea(List<BlockVector2> points){
-        int axis = points.get(0).getZ();
-        int total = 0;
-        int h,a,b;
-        a = 0;
-        for (int i = 1; i < points.size(); i++) {
-            h = points.get(i).getBlockX() - points.get(i-1).getBlockX();
-            b = a;
-            a = points.get(i).getBlockZ() - axis;
-            total += ((a+b)/2)*h;
-        }
-        h = points.get(0).getBlockX() - points.get(points.size()-1).getBlockX();
-        b = a;
-        a = points.get(0).getBlockZ() - axis;
-        total += ((a+b)/2)*h;
-        return total;
+    public static int polyArea(List<BlockVector2> points){
+        Polygonal2DRegion region = new Polygonal2DRegion(new BukkitWorld(Bukkit.getWorld("world")),points,0,0);
+        EditSession es = WorldEdit.getInstance().getEditSessionFactory().getEditSession(new BukkitWorld(Bukkit.getWorld("world")), Integer.MAX_VALUE);
+        return es.countBlocks(region, Masks.alwaysTrue()) + 1; //this function reliably miscounts by one in all my testing. I don't know why.
     }
 }

--- a/wg7adapter/src/main/java/net/alex9849/adapters/WG7Region.java
+++ b/wg7adapter/src/main/java/net/alex9849/adapters/WG7Region.java
@@ -5,6 +5,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
+import com.sk89q.worldguard.protection.regions.ProtectedPolygonalRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionType;
 import net.alex9849.inter.WGRegion;
@@ -18,9 +19,15 @@ import java.util.UUID;
 public class WG7Region extends WGRegion {
 
     private ProtectedRegion region;
+    private int Volume;
 
     WG7Region(ProtectedRegion region) {
         this.region = region;
+        if(region instanceof ProtectedPolygonalRegion){
+            Volume = PolyArea(region.getPoints()) * (region.getMaximumPoint().getBlockY()-region.getMinimumPoint().getBlockY());
+        } else {
+            Volume = region.volume();
+        }
     }
 
     public Vector getMaxPoint() {
@@ -129,7 +136,7 @@ public class WG7Region extends WGRegion {
 
     @Override
     public int getVolume() {
-        return this.region.volume();
+        return this.Volume;
     }
 
     @Override
@@ -174,5 +181,23 @@ public class WG7Region extends WGRegion {
 
     public boolean isCuboid() {
         return this.region.getType() == RegionType.CUBOID;
+    }
+
+    private static int PolyArea(List<BlockVector2> points){
+        int axis = points.get(0).getZ();
+        int total = 0;
+        int h,a,b;
+        a = 0;
+        for (int i = 1; i < points.size(); i++) {
+            h = points.get(i).getBlockX() - points.get(i-1).getBlockX();
+            b = a;
+            a = points.get(i).getBlockZ() - axis;
+            total += ((a+b)/2)*h;
+        }
+        h = points.get(0).getBlockX() - points.get(points.size()-1).getBlockX();
+        b = a;
+        a = points.get(0).getBlockZ() - axis;
+        total += ((a+b)/2)*h;
+        return total;
     }
 }


### PR DESCRIPTION
I took another crack at volume/area for 2d Poly regions. This time I opted to find the method for //count in the worldedit API and used that instead. This new calculation is much more accurate, as indicated by the below screenshots. Hopefully, this code is much more satisfactory.

Autoprice was set at m_2, with a price of $1/block. All regions are polygonal regions.

![2021-01-26_16 12 31](https://user-images.githubusercontent.com/12719375/105950518-5fa98880-6023-11eb-8a80-a6b4e59b4aa0.png)
Region bounds indicated by large hole in the ground


![2021-01-26_16 14 27](https://user-images.githubusercontent.com/12719375/105950565-718b2b80-6023-11eb-8334-1012032e8803.png)
Region bounds indicated by orange/white plane


The plateau was created by selecting the region bounds with worldguard and //move-ing them up out of the ground, so should include everything that is inside the region. 
