### PR TITLE
resetRegion: first unsell, then restore prevents: cannot unsell if no schematic present

### DIFF
--- a/advancedregionmarket/src/main/java/net/alex9849/arm/regions/Region.java
+++ b/advancedregionmarket/src/main/java/net/alex9849/arm/regions/Region.java
@@ -1056,8 +1056,11 @@ public abstract class Region implements Saveable {
     }
 
     public void resetRegion(ActionReason actionReason, boolean logToConsole) throws SchematicNotFoundException, ProtectionOfContinuanceException {
-        this.restoreRegion(actionReason, logToConsole, false);
+        if (this.isProtectionOfContinuance()) {
+            throw new ProtectionOfContinuanceException();
+        }
         this.unsell(actionReason, logToConsole, true);
+        this.restoreRegion(actionReason, logToConsole, false);
         this.extraEntitys.clear();
         this.extraTotalEntitys = 0;
         this.queueSave();


### PR DESCRIPTION
When doing /arm reset and there's no schematic present for that region, we want at least the region being unsold. 
The staff member is already aware of that schematic failure because of the error message in the chat and can handle this.
So I just changed the order of unsell and restore being made internally when resetting a region.