### PR TITLE
Add config option for custom item model data for RegionKinds

### DIFF
--- a/advancedregionmarket/src/main/java/net/alex9849/arm/gui/ClickItem.java
+++ b/advancedregionmarket/src/main/java/net/alex9849/arm/gui/ClickItem.java
@@ -36,6 +36,13 @@ public class ClickItem extends ItemStack {
         itemStack.setItemMeta(itemMeta);
         return this;
     }
+    
+    public ClickItem setCustomItemModel(int customItemModel) {
+    	ItemMeta itemMeta = this.itemStack.getItemMeta();
+        if(customItemModel != -1) { itemMeta.setCustomModelData(customItemModel); }
+        itemStack.setItemMeta(itemMeta);
+        return this;
+    }
 
     public ClickItem addClickAction(@Nullable ClickAction clickAction) {
         if(clickAction != null) {

--- a/advancedregionmarket/src/main/java/net/alex9849/arm/gui/Gui.java
+++ b/advancedregionmarket/src/main/java/net/alex9849/arm/gui/Gui.java
@@ -497,6 +497,7 @@ public class Gui implements Listener {
                 ClickItem clickItem = new ClickItem(regionKind.getMaterial())
                         .setName(regionKind.replaceVariables(Messages.GUI_REGIONFINDER_REGIONKIND_NAME))
                         .setLore(regionKind.getLore())
+                        .setCustomItemModel(regionKind.getCustomItemModel())
                         .addClickAction(p -> {
                             Gui.openRegionFinderSellTypeSelector(player, AdvancedRegionMarket.getInstance()
                                     .getRegionManager().getBuyableRegions(regionKind), pl -> Gui.openRegionFinder(player, goBackAction));
@@ -804,6 +805,7 @@ public class Gui implements Listener {
         ItemStack stack = new ItemStack(region.getRegionKind().getMaterial());
         ItemMeta meta = stack.getItemMeta();
         meta.setDisplayName(regionDisplayName);
+        if(region.getRegionKind().getCustomItemModel() != -1) { meta.setCustomModelData(region.getRegionKind().getCustomItemModel()); }
 
         List<String> regionLore = new ArrayList<>();
         if (region instanceof RentRegion) {

--- a/advancedregionmarket/src/main/java/net/alex9849/arm/regionkind/RegionKind.java
+++ b/advancedregionmarket/src/main/java/net/alex9849/arm/regionkind/RegionKind.java
@@ -20,6 +20,7 @@ public class RegionKind implements LimitGroupElement, Saveable {
     public static RegionKind SUBREGION = new RegionKind("Subregion", MaterialFinder.getRedBed(), new ArrayList<String>(), "Subregion", false, false);
     private String name;
     private Material material;
+    private int customItemModel;
     private List<String> lore;
     private String displayName;
     private boolean displayInRegionFinder;
@@ -73,7 +74,7 @@ public class RegionKind implements LimitGroupElement, Saveable {
         this.stringReplacer = new StringReplacer(variableReplacements, 20);
     }
 
-    public RegionKind(String name, Material material, List<String> lore, String displayName, boolean displayInRegionFinder, boolean displayInLimits) {
+    public RegionKind(String name, Material material, List<String> lore, String displayName, boolean displayInRegionFinder, boolean displayInLimits, int customItemModel) {
         this.name = name;
         this.material = material;
         this.lore = lore;
@@ -81,19 +82,23 @@ public class RegionKind implements LimitGroupElement, Saveable {
         this.displayInRegionFinder = displayInRegionFinder;
         this.displayInLimits = displayInLimits;
         this.needsSave = false;
+        this.customItemModel = customItemModel;
     }
+    
+    public RegionKind(String name, Material material, List<String> lore, String displayName, boolean displayInRegionFinder, boolean displayInLimits) { this(name, material, lore, displayName, displayInRegionFinder, displayInLimits, -1); }
 
     public static RegionKind parse(ConfigurationSection confSection, String name) {
         Material material = MaterialFinder.getMaterial(confSection.getString("item"));
         if (material == null) {
             material = MaterialFinder.getRedBed();
         }
+        int customItemModel = confSection.getInt("customItemModel", -1);
         String displayName = confSection.getString("displayName");
         boolean displayInLimits = confSection.getBoolean("displayInLimits");
         boolean displayInRegionfinder = confSection.getBoolean("displayInRegionfinder");
         List<String> lore = new ArrayList<>(confSection.getStringList("lore"));
-
-        return new RegionKind(name, material, lore, displayName, displayInRegionfinder, displayInLimits);
+        
+        return new RegionKind(name, material, lore, displayName, displayInRegionfinder, displayInLimits, customItemModel);
     }
 
     public String getName() {
@@ -161,6 +166,15 @@ public class RegionKind implements LimitGroupElement, Saveable {
         this.displayInLimits = displayInLimits;
         this.queueSave();
     }
+    
+    public int getCustomItemModel() {
+    	return customItemModel;
+    }
+    
+    public void setCustomItemModel(int customItemModel) {
+    	this.customItemModel = customItemModel;
+    	this.queueSave();
+    }
 
     public String replaceVariables(String message) {
         return this.stringReplacer.replace(message).toString();
@@ -170,6 +184,7 @@ public class RegionKind implements LimitGroupElement, Saveable {
     public ConfigurationSection toConfigurationSection() {
         ConfigurationSection confSection = new YamlConfiguration();
         confSection.set("item", this.getMaterial().toString());
+        if(this.customItemModel != -1) { confSection.set("customItemModel", this.getCustomItemModel()); }
         confSection.set("displayName", this.getRawDisplayName());
         confSection.set("displayInLimits", this.isDisplayInLimits());
         confSection.set("displayInRegionfinder", this.isDisplayInRegionfinder());


### PR DESCRIPTION
Adds an optional config value in regionkinds.yml, which allows the item shown in the GUI to have a custom item model parameter set on it, to allow servers to use resourcepacks to change how the icon appears