### PR TITLE
Corrected typo in ParticleBorder

### DIFF
--- a/advancedregionmarket/src/main/java/net/alex9849/arm/handler/listener/SignModifyListener.java
+++ b/advancedregionmarket/src/main/java/net/alex9849/arm/handler/listener/SignModifyListener.java
@@ -219,10 +219,10 @@ public class SignModifyListener implements Listener {
                 block.setCancelled(true);
                 throw new InputException(block.getPlayer(), Messages.NO_PERMISSION);
             }
-            double loc_x = block.getBlock().getLocation().getX();
-            double loc_y = block.getBlock().getLocation().getY();
-            double loc_z = block.getBlock().getLocation().getZ();
-            Location loc = new Location(block.getBlock().getWorld(), loc_x, loc_y, loc_z);
+            double location_x = block.getBlock().getLocation().getX();
+            double location_y = block.getBlock().getLocation().getY();
+            double location_z = block.getBlock().getLocation().getZ();
+            Location loc = new Location(block.getBlock().getWorld(), location_x, location_y, location_z);
 
             if (block.getPlayer().hasPermission(Permission.ADMIN_REMOVE_SIGN)) {
                 this.removeSignAndSendMessages(region, loc, block.getPlayer());

--- a/advancedregionmarket/src/main/java/net/alex9849/arm/minifeatures/ParticleBorder.java
+++ b/advancedregionmarket/src/main/java/net/alex9849/arm/minifeatures/ParticleBorder.java
@@ -82,11 +82,11 @@ public class ParticleBorder {
         List<Location> particleLoc = new ArrayList<>();
 
         for (int i = 0; i < this.points.size(); i++) {
-            Vector point1bottem = new Vector(this.points.get(i).getBlockX(), this.depth, this.points.get(i).getBlockZ());
-            Vector point2bottem = new Vector(this.points.get(Math.floorMod(i + 1, this.points.size())).getBlockX(), this.depth, this.points.get(Math.floorMod(i + 1, this.points.size())).getBlockZ());
+            Vector point1bottom = new Vector(this.points.get(i).getBlockX(), this.depth, this.points.get(i).getBlockZ());
+            Vector point2bottom = new Vector(this.points.get(Math.floorMod(i + 1, this.points.size())).getBlockX(), this.depth, this.points.get(Math.floorMod(i + 1, this.points.size())).getBlockZ());
             Vector point1top = new Vector(this.points.get(i).getBlockX(), this.height, this.points.get(i).getBlockZ());
             Vector point2top = new Vector(this.points.get(Math.floorMod(i + 1, this.points.size())).getBlockX(), this.height, this.points.get(Math.floorMod(i + 1, this.points.size())).getBlockZ());
-            particleLoc.addAll(this.plotLine(point1bottem, point2bottem, this.world));
+            particleLoc.addAll(this.plotLine(point1bottom, point2bottom, this.world));
             particleLoc.addAll(this.plotLine(point1top, point2top, this.world));
             int pointX = this.points.get(i).getBlockX();
             int pointZ = this.points.get(i).getBlockZ();


### PR DESCRIPTION
Corrected typo in the variable names of ParticleBorder class by renaming point1bottem to point1bottom and point2bottem to point2bottom. Renamed variables loc_x, loc_y, and loc_z of SignModifyListener class to location_x, location_y, and location_z.