### PR TITLE
Pull-up method refactoring

### DIFF
--- a/arminterface/src/main/java/net/alex9849/inter/WorldGuardInterface.java
+++ b/arminterface/src/main/java/net/alex9849/inter/WorldGuardInterface.java
@@ -5,11 +5,14 @@ import com.sk89q.worldguard.protection.flags.InvalidFlagFormat;
 import com.sk89q.worldguard.protection.flags.RegionGroup;
 import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
 import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public abstract class WorldGuardInterface {
 
@@ -31,7 +34,16 @@ public abstract class WorldGuardInterface {
 
     public abstract RegionGroup parseFlagInput(RegionGroupFlag flag, String input) throws InvalidFlagFormat;
 
-    public abstract List<String> tabCompleteRegions(String regionName, World world);
+    public List<String> tabCompleteRegions(String regionName, World world) {
+        Map<String, ProtectedRegion> regions = this.getRegionManager(world).getRegions();
+        List<String> regionIds = new ArrayList<>();
+        for(Map.Entry<String, ProtectedRegion> entry : regions.entrySet()) {
+            if(entry.getKey().toLowerCase().startsWith(regionName.toLowerCase())) {
+                regionIds.add(entry.getValue().getId());
+            }
+        }
+        return regionIds;
+    }
 
     public abstract Flag fuzzyMatchFlag(String id);
 }

--- a/wg6_1adapter/src/main/java/net/alex9849/adapters/WorldGuard6_1.java
+++ b/wg6_1adapter/src/main/java/net/alex9849/adapters/WorldGuard6_1.java
@@ -82,16 +82,4 @@ public class WorldGuard6_1 extends WorldGuardInterface {
         return flag.parseInput(WorldGuardPlugin.inst(), null, input);
     }
 
-    @Override
-    public List<String> tabCompleteRegions(String regionName, World world) {
-        Map<String, ProtectedRegion> regions = this.getRegionManager(world).getRegions();
-        List<String> regionIds = new ArrayList<>();
-        for(Map.Entry<String, ProtectedRegion> entry : regions.entrySet()) {
-            if(entry.getKey().toLowerCase().startsWith(regionName.toLowerCase())) {
-                regionIds.add(entry.getValue().getId());
-            }
-        }
-        return regionIds;
-    }
-
 }

--- a/wg7adapter/src/main/java/net/alex9849/adapters/WorldGuard7.java
+++ b/wg7adapter/src/main/java/net/alex9849/adapters/WorldGuard7.java
@@ -94,16 +94,4 @@ public class WorldGuard7 extends WorldGuardInterface {
         return flag.parseInput(FlagContext.create().setInput(input).build());
     }
 
-    @Override
-    public List<String> tabCompleteRegions(String regionName, World world) {
-        Map<String, ProtectedRegion> regions = this.getRegionManager(world).getRegions();
-        List<String> regionIds = new ArrayList<>();
-        for(Map.Entry<String, ProtectedRegion> entry : regions.entrySet()) {
-            if(entry.getKey().toLowerCase().startsWith(regionName.toLowerCase())) {
-                regionIds.add(entry.getValue().getId());
-            }
-        }
-        return regionIds;
-    }
-
 }


### PR DESCRIPTION
Removed the method tabCompleteRegions from WorldGuard7 and WorldGuard6_1 classes since the method signature and implementation are identical, and created the same method in the super type WorldGuardInterface class.