### PR TITLE
Also update region when no signs attached

### DIFF
--- a/advancedregionmarket/src/main/java/net/alex9849/arm/regions/RegionManager.java
+++ b/advancedregionmarket/src/main/java/net/alex9849/arm/regions/RegionManager.java
@@ -30,6 +30,7 @@ import org.bukkit.block.Sign;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
 
 import java.io.File;
 import java.util.*;
@@ -939,6 +940,16 @@ public class RegionManager extends YamlFileManager<Region> {
             for (Region region : RegionManager.this) {
                 for (SignData signData : region.getSellSigns()) {
                     Location sLoc = signData.getLocation();
+                    DummyChunk chunk = DummyChunk.getUniqueDummyChunk(sLoc.getBlockX() >> 4, sLoc.getBlockZ() >> 4);
+                    List<Region> regions = signMap.get(chunk);
+                    if (regions == null) {
+                        regions = new ArrayList<>();
+                        signMap.put(chunk, regions);
+                    }
+                    regions.add(region);
+                }
+                if(region.getSellSigns().isEmpty()){
+                    Vector sLoc = region.getRegion().getMaxPoint();
                     DummyChunk chunk = DummyChunk.getUniqueDummyChunk(sLoc.getBlockX() >> 4, sLoc.getBlockZ() >> 4);
                     List<Region> regions = signMap.get(chunk);
                     if (regions == null) {


### PR DESCRIPTION
Regions without signs were not put in the rearanged update queue and thus skipped. This led to for example a Rentregion not beeing reset and the owner not being removed even if /arm info listed the region as expired