### PR TITLE
Fix PaperLib on 26.1+

### DIFF
--- a/advancedregionmarket/pom.xml
+++ b/advancedregionmarket/pom.xml
@@ -63,7 +63,7 @@
                             <shadedPattern>net.alex9849.arm.analytics</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>io.papermc.lib</pattern>
+                            <pattern>io.github.rvskele.paperlib</pattern>
                             <shadedPattern>net.alex9849.lib.paperlib</shadedPattern>
                         </relocation>
                     </relocations>

--- a/advancedregionmarket/src/main/java/net/alex9849/arm/gui/Gui.java
+++ b/advancedregionmarket/src/main/java/net/alex9849/arm/gui/Gui.java
@@ -1,7 +1,7 @@
 package net.alex9849.arm.gui;
 
 import com.sk89q.worldguard.protection.flags.*;
-import io.papermc.lib.PaperLib;
+import io.github.rvskele.paperlib.PaperLib;
 import net.alex9849.arm.AdvancedRegionMarket;
 import net.alex9849.arm.Messages;
 import net.alex9849.arm.Permission;

--- a/advancedregionmarket/src/main/java/net/alex9849/arm/handler/listener/SignClickListener.java
+++ b/advancedregionmarket/src/main/java/net/alex9849/arm/handler/listener/SignClickListener.java
@@ -1,6 +1,6 @@
 package net.alex9849.arm.handler.listener;
 
-import io.papermc.lib.PaperLib;
+import io.github.rvskele.paperlib.PaperLib;
 import net.alex9849.arm.AdvancedRegionMarket;
 import net.alex9849.arm.Messages;
 import net.alex9849.arm.exceptions.*;

--- a/advancedregionmarket/src/main/java/net/alex9849/arm/handler/listener/SignModifyListener.java
+++ b/advancedregionmarket/src/main/java/net/alex9849/arm/handler/listener/SignModifyListener.java
@@ -1,6 +1,6 @@
 package net.alex9849.arm.handler.listener;
 
-import io.papermc.lib.PaperLib;
+import io.github.rvskele.paperlib.PaperLib;
 import net.alex9849.arm.AdvancedRegionMarket;
 import net.alex9849.arm.Messages;
 import net.alex9849.arm.Permission;

--- a/advancedregionmarket/src/main/java/net/alex9849/arm/minifeatures/SignLinkMode.java
+++ b/advancedregionmarket/src/main/java/net/alex9849/arm/minifeatures/SignLinkMode.java
@@ -1,6 +1,6 @@
 package net.alex9849.arm.minifeatures;
 
-import io.papermc.lib.PaperLib;
+import io.github.rvskele.paperlib.PaperLib;
 import net.alex9849.arm.AdvancedRegionMarket;
 import net.alex9849.arm.Messages;
 import net.alex9849.arm.adapters.WGRegion;

--- a/arminterface/pom.xml
+++ b/arminterface/pom.xml
@@ -35,9 +35,9 @@
         </dependency>
         <!-- PaperLib library for Spigot <-> Paper compatibility -->
         <dependency>
-            <groupId>io.papermc</groupId>
-            <artifactId>paperlib</artifactId>
-            <version>1.0.8</version>
+            <groupId>io.github.rvskele</groupId>
+            <artifactId>PaperLib</artifactId>
+            <version>2.1.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/arminterface/src/main/java/net/alex9849/arm/adapters/signs/SignData.java
+++ b/arminterface/src/main/java/net/alex9849/arm/adapters/signs/SignData.java
@@ -1,6 +1,6 @@
 package net.alex9849.arm.adapters.signs;
 
-import io.papermc.lib.PaperLib;
+import io.github.rvskele.paperlib.PaperLib;
 import org.bukkit.Location;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;

--- a/mc1-14adapter/src/main/java/net/alex9849/arm/adapters/signs/SignData114.java
+++ b/mc1-14adapter/src/main/java/net/alex9849/arm/adapters/signs/SignData114.java
@@ -1,6 +1,6 @@
 package net.alex9849.arm.adapters.signs;
 
-import io.papermc.lib.PaperLib;
+import io.github.rvskele.paperlib.PaperLib;
 import net.alex9849.arm.adapters.util.MaterialFinder114;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/mc1-20adapter/src/main/java/net/alex9849/arm/adapters/signs/SignData120.java
+++ b/mc1-20adapter/src/main/java/net/alex9849/arm/adapters/signs/SignData120.java
@@ -1,6 +1,6 @@
 package net.alex9849.arm.adapters.signs;
 
-import io.papermc.lib.PaperLib;
+import io.github.rvskele.paperlib.PaperLib;
 import net.alex9849.arm.adapters.util.MaterialFinder120;
 import org.bukkit.Location;
 import org.bukkit.Material;


### PR DESCRIPTION
This resolves an issue in newer versions (26.1+) where the version check would fail and the library would fall back to the heavier Spigot methods. 

For now, I'm opening the PR this way, using my own forked version of PaperLib, which I find much more convenient.
If using third-party libraries is an issue, I recommend creating an internal helper method within the plugin that does basically the same.